### PR TITLE
Removed redundant ch.qos.logback dependency from pom.xml

### DIFF
--- a/camunda-kafka-polling-client/pom.xml
+++ b/camunda-kafka-polling-client/pom.xml
@@ -280,13 +280,6 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Dependency with <test> scope overrides OTB dep. and results
with error and NOP logging.

SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder
for further details.